### PR TITLE
bind zone format is the worst, and I should feel bad.

### DIFF
--- a/hq/README.md
+++ b/hq/README.md
@@ -22,6 +22,10 @@ signs the zones.  OpenBSD's authoritative name server, `nsd`, is what
 actually serves the signed zones. Its config file is here as `nsd.conf`.
 
 
+TODO(weaver) : Fix zone signing so that failures are exposed on build.
+TODO(weaver) : Fix zone installation so two makes aren't required.
+
+
 ### caveats about build
 1. You'll need to manually enter the softhsm "user" PIN
 into `/etc/opendnssec/conf.xml` after a `doas make hq`, since we don't

--- a/hq/layeraleph.com
+++ b/hq/layeraleph.com
@@ -1,13 +1,14 @@
 $TTL 3600
 @	IN SOA	ns1 named (
-				2018071006 ; serial
+				2018072701 ; serial
 				300        ; refresh (5m)
 				600        ; retry (5m)
 				8467200    ; expire (14w)
 				3600       ; minimum (1h)
 				)
-		NS	ns.layeraleph.com.
-		NS	ns6.gandi.net.
+
+@		NS	ns.layeraleph.com.
+@		NS	ns6.gandi.net.
 
 		IN A	100.36.223.12
 ns		IN A	100.36.223.12


### PR DESCRIPTION
The lack of newline here was a syntax error.
So, ods-signer was barfing when it tried to sign the zone with new signatures to replace the expired ones.
I added explicit '@' instead of relying on the behavior of 'empty name means previous name,' which special cases to the zone itself if it comes first.