### PR TITLE
DNSSEC: and endless fractal of suffering

### DIFF
--- a/hq/Makefile
+++ b/hq/Makefile
@@ -48,7 +48,7 @@ hq : /etc/acme-client.conf \
 /etc/opendnssec/kasp.xml : kasp.xml
 	install -o root -g _opendnssec -m 0640 \
 	  kasp.xml /etc/opendnssec/kasp.xml
-	ods-enforcer update all
+	ods-enforcer policy import
 
 /etc/pf.conf : pf.conf
 	install -o root -g wheel -m 0600 \

--- a/hq/kasp.xml
+++ b/hq/kasp.xml
@@ -15,8 +15,8 @@
 
 	<Policy name="default">
 		<Description> A policy with four year, 4096b KSKs and
-		  1 year, 2048b ZSKs. SOA Serial numbers are set with a
-		  classic YYYYMMDDxx format.</Description>
+		  1 year, 2048b ZSKs. SOA Serial numbers are preserved
+		  from the unsigned zones.</Description>
 		<Signatures>
 			<Resign>PT4H</Resign>
 			<Refresh>P6D</Refresh>
@@ -74,7 +74,7 @@
 			<SOA>
 				<TTL>PT3600S</TTL>
 				<Minimum>PT172800S</Minimum>
-				<Serial>datecounter</Serial>
+				<Serial>keep</Serial>
 			</SOA>
 		</Zone>
 

--- a/hq/kasp.xml
+++ b/hq/kasp.xml
@@ -1,17 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--
+  
+  NOTE:  The default policy below is a TEMPLATE ONLY and should be reviewed
+         before used in any production environment. The administrator should
+         consult the OpenDNSSEC documentation before changing any parameters.
+         
+         If you can read this message, it is likely that this file has not
+         been reviewed nor updated.
+
+  -->
+
 <KASP>
 
 	<Policy name="default">
-		<Description> A policy with two year, 4096b KSKs and
-		  180 day, 2048b ZSKs. SOA Serial numbers are generated
-		  in a YYYYMMDDnn format by ODS.</Description>
+		<Description> A policy with four year, 4096b KSKs and
+		  1 year, 2048b ZSKs. SOA Serial numbers are set with a
+		  classic YYYYMMDDxx format.</Description>
 		<Signatures>
-			<Resign>PT2H</Resign>
-			<Refresh>P3D</Refresh>
+			<Resign>PT4H</Resign>
+			<Refresh>P6D</Refresh>
 			<Validity>
-				<Default>P14D</Default>
-				<Denial>P14D</Denial>
+				<Default>P21D</Default>
+				<Denial>P21D</Denial>
 			</Validity>
 			<Jitter>PT12H</Jitter>
 			<InceptionOffset>PT3600S</InceptionOffset>
@@ -33,15 +44,15 @@
 		<Keys>
 			<!-- Parameters for both KSK and ZSK -->
 			<TTL>PT3600S</TTL>
-			<RetireSafety>PT3600S</RetireSafety>
-			<PublishSafety>PT3600S</PublishSafety>
+			<RetireSafety>PT360S</RetireSafety>
+			<PublishSafety>PT360S</PublishSafety>
 			<!-- <ShareKeys/> -->
-			<Purge>P14D</Purge>
+			<Purge>P21D</Purge>
 
 			<!-- Parameters for KSK only -->
 			<KSK>
 				<Algorithm length="4096">8</Algorithm>
-				<Lifetime>P2Y</Lifetime>
+				<Lifetime>P4Y</Lifetime>
 				<!--
 				  TODO(weaver,mikey): use a hardware
 				  pkcs11 device
@@ -52,7 +63,7 @@
 			<!-- Parameters for ZSK only -->
 			<ZSK>
 				<Algorithm length="2048">8</Algorithm>
-				<Lifetime>P180D</Lifetime>
+				<Lifetime>P1Y</Lifetime>
 				<Repository>SoftHSM</Repository>
 				<!-- <ManualRollover/> -->
 			</ZSK>

--- a/hq/layeraleph.com
+++ b/hq/layeraleph.com
@@ -1,6 +1,6 @@
 $TTL 3600
 @	IN SOA	ns1 named (
-				2019080200 ; serial
+				2019193001 ; serial
 				300        ; refresh (5m)
 				600        ; retry (5m)
 				8467200    ; expire (14w)

--- a/hq/layerbeh.com
+++ b/hq/layerbeh.com
@@ -1,6 +1,6 @@
 $TTL 3600
 @	IN SOA	ns1 named (
-				2019080200 ; serial
+				2019193001 ; serial
 				300        ; refresh (5m)
 				600        ; retry (5m)
 				8467200    ; expire (14w)

--- a/korba/Makefile
+++ b/korba/Makefile
@@ -59,7 +59,7 @@ korba : /etc/acme-client.conf \
 /etc/opendnssec/kasp.xml : kasp.xml
 	install -o root -g _opendnssec -m 0640 \
 	  kasp.xml /etc/opendnssec/kasp.xml
-	ods-enforcer update all
+	ods-enforcer policy import
 
 /etc/pf.conf : pf.conf
 	install -o root -g wheel -m 0600 \

--- a/korba/kasp.xml
+++ b/korba/kasp.xml
@@ -13,16 +13,16 @@
 
 <KASP>
 
-	<Policy name="nodeless-default">
-		<Description> A policy with two year, 4096b KSKs and
-		  180 day, 2048b ZSKs. SOA Serial numbers are set with a
+	<Policy name="default">
+		<Description> A policy with four year, 4096b KSKs and
+		  1 year, 2048b ZSKs. SOA Serial numbers are set with a
 		  classic YYYYMMDDxx format.</Description>
 		<Signatures>
-			<Resign>PT2H</Resign>
-			<Refresh>P3D</Refresh>
+			<Resign>PT4H</Resign>
+			<Refresh>P6D</Refresh>
 			<Validity>
-				<Default>P14D</Default>
-				<Denial>P14D</Denial>
+				<Default>P21D</Default>
+				<Denial>P21D</Denial>
 			</Validity>
 			<Jitter>PT12H</Jitter>
 			<InceptionOffset>PT3600S</InceptionOffset>
@@ -44,15 +44,15 @@
 		<Keys>
 			<!-- Parameters for both KSK and ZSK -->
 			<TTL>PT3600S</TTL>
-			<RetireSafety>PT3600S</RetireSafety>
-			<PublishSafety>PT3600S</PublishSafety>
+			<RetireSafety>PT360S</RetireSafety>
+			<PublishSafety>PT360S</PublishSafety>
 			<!-- <ShareKeys/> -->
-			<Purge>P14D</Purge>
+			<Purge>P21D</Purge>
 
 			<!-- Parameters for KSK only -->
 			<KSK>
 				<Algorithm length="4096">8</Algorithm>
-				<Lifetime>P2Y</Lifetime>
+				<Lifetime>P4Y</Lifetime>
 				<!--
 				  TODO(weaver,mikey): use a hardware
 				  pkcs11 device
@@ -63,7 +63,7 @@
 			<!-- Parameters for ZSK only -->
 			<ZSK>
 				<Algorithm length="2048">8</Algorithm>
-				<Lifetime>P180D</Lifetime>
+				<Lifetime>P1Y</Lifetime>
 				<Repository>SoftHSM</Repository>
 				<!-- <ManualRollover/> -->
 			</ZSK>

--- a/korba/kasp.xml
+++ b/korba/kasp.xml
@@ -74,7 +74,7 @@
 			<SOA>
 				<TTL>PT3600S</TTL>
 				<Minimum>PT172800S</Minimum>
-				<Serial>datecounter</Serial>
+				<Serial>keep</Serial>
 			</SOA>
 		</Zone>
 

--- a/korba/zones/ice-nine.org
+++ b/korba/zones/ice-nine.org
@@ -1,6 +1,6 @@
 $TTL 3600
 @ 	IN SOA ns named (
-				2019072600 ; serial
+				2019161030 ; serial
 				1800       ; refresh, 30 min
 				300        ; retry 5 min
 				8467200    ; expire 2 weeks

--- a/korba/zones/mcweavers.net
+++ b/korba/zones/mcweavers.net
@@ -1,5 +1,5 @@
 @ 	IN SOA ns named (
-				2019072600 ; serial
+				2019103010 ; serial
 				1800       ; refresh, 30 min
 				300        ; retry 5 min
 				7776000    ; expire 90 days

--- a/korba/zones/mjw.wtf
+++ b/korba/zones/mjw.wtf
@@ -1,6 +1,6 @@
 $TTL 3600
 @	IN SOA	ns named (
-				2019072600 ; serial
+				2019103010 ; serial
 				300        ; refresh (5 min)
 				300        ; retry (5 min)
 				8467200    ; expire (14 weeks)

--- a/korba/zones/nodeless.net
+++ b/korba/zones/nodeless.net
@@ -1,6 +1,6 @@
 $TTL 3600
 @	IN SOA	ns1 named (
-				2019072600  ; serial
+				2019103010  ; serial
 				1800       ; refresh (30 min)
 				300        ; retry (5 min)
 				8467200    ; expire (14 weeks)


### PR DESCRIPTION
Recording here in case I ever get around to root causing this.

OpenDNSsec, on both the NSes, circled into a degenerate behavior of some kind over the past 6 months. I'm guessing the migration from 1.4 -> 2.1 has something to do with it.

Symptoms at the end:
- 1+GB softhsm db containing a zillion records, which OOM'd the signer process after minutes of parsing.
- Runaway SOA serial numbers like "2019163477", presumably from hundreds of thousands of signature attempts?

Fixed by rebuilding DNSSEC from the root for all zones, including a manual workaround for serial numbers until 2020.